### PR TITLE
feat: Improve tox configuration

### DIFF
--- a/packages/actions-python-core/pyproject.toml
+++ b/packages/actions-python-core/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 Homepage = "https://github.com/actions-python/toolkit"
 
 [tool.hatch.build]
-exclude = [ "/tests"]
+exclude = ["/tests"]
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -64,28 +64,23 @@ dev-dependencies = [
 ]
 
 [tool.rye.scripts]
-format = {chain = ["format:ruff-check .", "format:ruff-format ."]}
-"format:ruff-check" = {cmd = "ruff check --fix --exit-non-zero-on-fix"}
-"format:ruff-format" = {cmd = "ruff format"}
-lint = {chain = ["lint:mypy", "lint:pyright", "lint:ruff-check .", "lint:ruff-format ."]}
-"lint:mypy" = {cmd = "mypy ."}
-"lint:pyright" = {cmd = "pyright ."}
-"lint:ruff-check" = {cmd = "ruff check --exit-non-zero-on-fix"}
-"lint:ruff-format" = {cmd = "ruff format --check"}
-test = {cmd = "tox"}
+format = { chain = ["format:ruff-check .", "format:ruff-format ."] }
+"format:ruff-check" = { cmd = "ruff check --fix --exit-non-zero-on-fix" }
+"format:ruff-format" = { cmd = "ruff format" }
+lint = { chain = ["lint:mypy", "lint:pyright", "lint:ruff-check .", "lint:ruff-format ."] }
+"lint:mypy" = { cmd = "mypy ." }
+"lint:pyright" = { cmd = "pyright ." }
+"lint:ruff-check" = { cmd = "ruff check --exit-non-zero-on-fix" }
+"lint:ruff-format" = { cmd = "ruff format --check" }
+test = { cmd = "tox --parallel" }
 
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py39, py310, py311, py312
-skip_missing_interpreters = false
+envlist = py{39,310,311,312}
 rye_discovery = true
+skip_missing_interpreters = false
 
 [testenv]
-allowlist_externals = rye
-skip_install = true
-deps = []
-commands =
-    rye sync --no-lock
-    rye run python -m unittest discover -s tests
+commands = python -m unittest discover -s tests
 """

--- a/packages/actions-python-core/tests/utils.py
+++ b/packages/actions-python-core/tests/utils.py
@@ -1,9 +1,15 @@
 import contextlib
 import io
 import os
+import sys
 import typing
 
-P = typing.ParamSpec("P")
+if sys.version_info < (3, 10):
+    import typing_extensions
+
+    P = typing_extensions.ParamSpec("P")
+else:
+    P = typing.ParamSpec("P")
 
 
 def capture_output(

--- a/packages/actions-python-github/pyproject.toml
+++ b/packages/actions-python-github/pyproject.toml
@@ -63,28 +63,25 @@ dev-dependencies = [
 ]
 
 [tool.rye.scripts]
-format = {chain = ["format:ruff-check .", "format:ruff-format ."]}
-"format:ruff-check" = {cmd = "ruff check --fix --exit-non-zero-on-fix"}
-"format:ruff-format" = {cmd = "ruff format"}
-lint = {chain = ["lint:mypy", "lint:pyright", "lint:ruff-check .", "lint:ruff-format ."]}
-"lint:mypy" = {cmd = "mypy ."}
-"lint:pyright" = {cmd = "pyright ."}
-"lint:ruff-check" = {cmd = "ruff check --exit-non-zero-on-fix"}
-"lint:ruff-format" = {cmd = "ruff format --check"}
-test = {cmd = "tox"}
+format = { chain = ["format:ruff-check .", "format:ruff-format ."] }
+"format:ruff-check" = { cmd = "ruff check --fix --exit-non-zero-on-fix" }
+"format:ruff-format" = { cmd = "ruff format" }
+lint = { chain = ["lint:mypy", "lint:pyright", "lint:ruff-check .", "lint:ruff-format ."] }
+"lint:mypy" = { cmd = "mypy ." }
+"lint:pyright" = { cmd = "pyright ." }
+"lint:ruff-check" = { cmd = "ruff check --exit-non-zero-on-fix" }
+"lint:ruff-format" = { cmd = "ruff format --check" }
+test = { cmd = "tox --parallel" }
 
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py39, py310, py311, py312
-skip_missing_interpreters = false
+envlist = py{39,310,311,312}
 rye_discovery = true
+skip_missing_interpreters = false
 
 [testenv]
-allowlist_externals = rye
-skip_install = true
-deps = []
-commands =
-    rye sync --no-lock
-    rye run python -m unittest discover -s tests
+commands = python -m unittest discover -s tests
+deps =
+    -e ../actions-python-core
 """


### PR DESCRIPTION
- Use tox with parallel option
- Replace dependencies installation with tox's default package builder
  - `rye sync` installs and uses root virtualenv
- Fix `typing.ParamSpec` usage for python 3.9