### PR TITLE
fix: Fix package-deploy pipeline permissions

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -12,6 +12,10 @@ jobs:
   package-deploy:
     name: Deploy
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
     strategy:
       matrix:
         workspace: ["actions-python-core", "actions-python-github"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev-dependencies = [
     "mypy~=1.5.1",
     "pre-commit>=3.4.0",
     "pyproject-fmt>=1.2.0",
-    "pyright~=1.1.327",
+    "pyright~=1.1.329",
     "ruff~=0.0.292",
     "tox~=4.11.3",
     "tox-rye @ git+https://github.com/bluss/tox-rye@0.3.0",


### PR DESCRIPTION
- This pr fixes package-deploy permission errors.
- Issue came from https://github.com/actions-python/toolkit/pull/3

```sh
Error: Trusted publishing exchange failure: 
OpenID Connect token retrieval failed: GitHub: missing or insufficient OIDC token permissions, the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable was unset
```